### PR TITLE
Enhance Android CI workflow by caching Gradle dependencies

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -13,6 +13,16 @@ jobs:
 
     steps:
     - uses: actions/checkout@v5
+    - name: Cache Gradle dependencies
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+        key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+        restore-keys: |
+          gradle-${{ runner.os }}-
+    - uses: actions/checkout@v5
     - name: set up JDK 17
       uses: actions/setup-java@v5
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,9 @@ google-services.json
 
 # Android Profiling
 *.hprof
+
+#Ignore vscode AI rules
+.github/instructions/codacy.instructions.md
+
+# MacOS files
+.DS_Store


### PR DESCRIPTION
…ng .gitignore for VSCode AI rules